### PR TITLE
KSI-CNA-04: Use immutable infrastructure with strictly defined functionality and privileges by default

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -33,3 +33,13 @@ vars:
     - "aws_rds_clusters"
     - "aws_rds_instances"
     - "aws_ec2_vpcs"
+  ksi_cna_04_tables:
+    - "k8s_apps_deployments"
+    - "k8s_apps_stateful_sets"
+    - "k8s_apps_daemon_sets"
+    - "k8s_batch_cron_jobs"
+  ksi_cna_04_allowed_registries: []
+  k8s_deployment_method_labels:
+    - key: ""
+      values: []
+      operator: "in"

--- a/macros/k8s/k8s_images_should_use_immutable_tags.sql
+++ b/macros/k8s/k8s_images_should_use_immutable_tags.sql
@@ -1,0 +1,21 @@
+{% macro k8s_images_should_use_immutable_tags(framework, check_id) %}
+  {{ return(adapter.dispatch('k8s_images_should_use_immutable_tags')(framework, check_id)) }}
+{% endmacro %}
+
+{% macro default__k8s_images_should_use_immutable_tags(framework, check_id) %}{% endmacro %}
+
+{% macro bigquery__k8s_images_should_use_immutable_tags(framework, check_id) %}
+
+select
+    '{{ framework }}' as framework,
+    '{{ check_id }}' as check_id,
+    'Kubernetes images should use versioned tags instead of named aliases' as title,
+    CONCAT(context, '.', namespace, '.', resource_name, '.', container_name) as identifier,
+    null as metadata,
+    case when image_tag IN ('master', 'latest', 'stable')
+        then 'fail'
+        else 'pass'
+    end as status,
+    null as tags
+from {{ full_table_name("k8s_container_images") }}
+    {% endmacro %}

--- a/macros/k8s/k8s_images_should_use_internal_registry.sql
+++ b/macros/k8s/k8s_images_should_use_internal_registry.sql
@@ -1,0 +1,23 @@
+{% macro k8s_images_should_use_internal_registry(framework, check_id) %}
+  {{ return(adapter.dispatch('k8s_images_should_use_internal_registry')(framework, check_id)) }}
+{% endmacro %}
+
+{% macro default__k8s_images_should_use_internal_registry(framework, check_id) %}{% endmacro %}
+
+{% macro bigquery__k8s_images_should_use_internal_registry(framework, check_id) %}
+with images as (
+    select image_name from {{ full_table_name("k8s_container_images") }} group by image_name
+)
+select
+    '{{ framework }}' as framework,
+    '{{ check_id }}' as check_id,
+    'Kubernetes images should use an internal registry' as title,
+    image_name as identifier,
+    null as metadata,
+    case when JSON_EXTRACT_SCALAR(FORMAT("%T", NET.HOST(image_name))) IN ({{ to_sql_list(var("ksi_cna_04_allowed_registries")) }})
+        then 'pass'
+        else 'fail'
+    end as status,
+    null as tags
+from images
+    {% endmacro %}

--- a/macros/k8s/k8s_workloads_should_be_immutable.sql
+++ b/macros/k8s/k8s_workloads_should_be_immutable.sql
@@ -1,0 +1,43 @@
+{% macro k8s_workloads_should_be_immutable(framework, check_id) %}
+  {{ return(adapter.dispatch('k8s_workloads_should_be_immutable')(framework, check_id)) }}
+{% endmacro %}
+
+{% macro default__k8s_workloads_should_be_immutable(framework, check_id) %}{% endmacro %}
+
+{% macro bigquery__k8s_workloads_should_be_immutable(framework, check_id) %}
+{% set k8s_deployment_method_labels = var('k8s_deployment_method_labels') %}
+WITH coalesced_data AS (
+  {%- for table in var('ksi_cna_04_tables') -%}
+    select
+      name as resource_name,
+      namespace as namespace,
+      '{{ table }}' as resource_type,
+      context as context,
+      labels
+    from {{ full_table_name(table) }}
+    where {{ partition_filter() }}
+    {% if not loop.last %} {{ union() }} {% endif %}
+  {%- endfor -%}
+)
+select
+    '{{ framework }}' as framework,
+    '{{ check_id }}' as check_id,
+    'Kubernetes workloads should be immutable' as title,
+    CONCAT(context, '.', namespace, '.', resource_name) as identifier,
+    null as metadata,
+    case
+        when {%- for check in k8s_deployment_method_labels -%}
+            {% if check['operator'] == 'in' %}
+            JSON_EXTRACT_SCALAR(labels, "$['{{ check["key"] }}']") IN ({{ to_sql_list(check["values"]) }})
+            {% elif check['operator'] == 'exists' %}
+            JSON_EXTRACT_SCALAR(labels, "$['{{ check["key"] }}']") IS NOT NULL
+            {% endif %}
+            {% if not loop.last %} OR {% endif %}
+            {%- endfor -%}
+        then 'pass'
+        else 'fail'
+    end as status,
+    labels as tags
+from coalesced_data
+
+{% endmacro %}

--- a/models/fedramp_ksis.sql
+++ b/models/fedramp_ksis.sql
@@ -15,7 +15,7 @@ with
             {{ union() }}
         ({{ k8s_workloads_should_be_immutable('KSI-CNA-04', '1.1') }})
             {{ union() }}
-        ({{ k8s_images_should_use_internal_registry('KSI-CNA-05', '1.2') }})
+        ({{ k8s_images_should_use_internal_registry('KSI-CNA-04', '1.2') }})
             {{ union() }}
 
         -- KSI-CNA-06: Design systems for high availability and rapid recovery

--- a/models/fedramp_ksis.sql
+++ b/models/fedramp_ksis.sql
@@ -10,6 +10,14 @@ with
         ({{ aws_resources_should_be_managed_by_iac('KSI-CMT-02', '1.1') }})
             {{ union() }}
 
+        -- KSI-CNA-04: Use immutable infrastructure with strictly defined functionality and privileges by default
+        ({{ k8s_images_should_use_immutable_tags('KSI-CNA-04', '1.0') }})
+            {{ union() }}
+        ({{ k8s_workloads_should_be_immutable('KSI-CNA-04', '1.1') }})
+            {{ union() }}
+        ({{ k8s_images_should_use_internal_registry('KSI-CNA-05', '1.2') }})
+            {{ union() }}
+
         -- KSI-CNA-06: Design systems for high availability and rapid recovery
         ({{ vpcs_should_have_subnets_in_multiple_azs('KSI-CNA-06', '1.0')}})
             {{ union() }}

--- a/vars.json.example
+++ b/vars.json.example
@@ -1,4 +1,5 @@
 {
   "image_signing_webhook": "",
   "policy_enforcement_crds": []
+  "ksi_cna_04_allowed_registries": []
 }


### PR DESCRIPTION
- Verifies that all Kubernetes images are using immutable tags
- Verify Kubernetes workloads are managed by one of the allowed internal systems
- Verify images use one of the allowed internal registries