### PR TITLE
KSI-SVC-06: Ensure KMS keys are rotated

### DIFF
--- a/macros/aws/aws_cisv3_mapping.sql
+++ b/macros/aws/aws_cisv3_mapping.sql
@@ -1,0 +1,19 @@
+{% macro aws_cisv3_mapping(framework, check_id, cis_check_id) %}
+  {{ return(adapter.dispatch('aws_cisv3_mapping')(framework, check_id, cis_check_id)) }}
+{% endmacro %}
+
+{% macro default__aws_cisv3_mapping(framework, check_id, cis_check_id) %}{% endmacro %}
+
+{% macro bigquery__aws_cisv3_mapping(framework, check_id, cis_check_id) %}
+select
+    '{{ framework }}' as framework,
+    '{{ check_id }}' as check_id,
+    title,
+    resource_id as identifier,
+    null as metadata,
+    status,
+    JSON_OBJECT() as tags
+from {{ ref("aws_compliance__cis_v3_0_0")}}
+where check_id = '{{ cis_check_id }}'
+
+{% endmacro %}

--- a/macros/aws/kms/key_rotation_enabled.sql
+++ b/macros/aws/kms/key_rotation_enabled.sql
@@ -18,6 +18,8 @@ select
 FROM
   {{ full_table_name("aws_kms_keys") }} akk
 LEFT JOIN
-  {{ full_table_name("aws_kms_key_rotation_statuses") }} akkrs on akk.arn = akkrs.key_arn
+  {{ full_table_name("aws_kms_key_rotation_statuses") }} akkrs
+on akk.arn = akkrs.key_arn
+and {{ partition_join("akk", "akkrs") }}
 where {{ partition_filter("akk") }}
 {% endmacro %}

--- a/macros/aws/kms/rotation_enabled_for_customer_key.sql
+++ b/macros/aws/kms/rotation_enabled_for_customer_key.sql
@@ -17,6 +17,8 @@ select
     else 'pass'
   end as status
 from {{ full_table_name("aws_kms_keys") }} akk
-left join {{ full_table_name("aws_kms_key_rotation_statuses") }} akkrs on akk.arn = akkrs.key_arn
+left join {{ full_table_name("aws_kms_key_rotation_statuses") }} akkrs
+on akk.arn = akkrs.key_arn
+and {{ partition_join("akk", "akkrs") }}
 where {{ partition_filter("akk") }}
 {% endmacro %}

--- a/macros/partition_join.sql
+++ b/macros/partition_join.sql
@@ -1,0 +1,3 @@
+{% macro partition_join(left, right) %}
+    TIMESTAMP_TRUNC({{ left }}._cq_sync_time, DAY) = TIMESTAMP_TRUNC({{ right }}._cq_sync_time, DAY)
+{% endmacro %}

--- a/models/fedramp_ksis.sql
+++ b/models/fedramp_ksis.sql
@@ -51,6 +51,10 @@ with
         ({{ k8s_image_enforcement_policies_should_not_ignore_failures('KSI-SVC-04', '1.2') }})
             {{ union() }}
 
+        -- KSI-SVC-06: Use automated key management systems to manage, protect, and regularly rotate digital keys and certificates.
+        ({{ aws_cisv3_mapping('KSI-SVC-06', '1.0', '3.6') }}) -- Ensure Key rotation is enabled for all customer managed KMS keys
+            {{ union() }}
+
         -- KSI-MLA-04: Perform authenticated vulnerability scanning on information resources
         ({{ ec2_instances_should_be_scanned_by_inspector('KSI-MLA-04', '1.0')}})
             {{ union() }}


### PR DESCRIPTION
This check leverages the existing KMS rotation check in our CIS compliance model to satisfy the control. 

It also adds a new `partition_join` macro which ensures joining across tables respects the current partition