### PR TITLE
Configure semaphore jobs to deploy github pages

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,8 @@ queue:
 blocks:
   - name: "Build and Test"
     dependencies: []
-    when: "branch != 'master'"
+    skip:
+      when: "branch == 'master'"
     task:
       prologue:
         commands:
@@ -38,7 +39,8 @@ blocks:
 
   - name: "Deploy GitHub Pages"
     dependencies: []
-    when: "branch == 'master'"
+    skip:
+      when: "branch != 'master'"
     task:
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,8 +24,8 @@ queue:
 blocks:
   - name: "Build and Test"
     dependencies: []
-    skip:
-      when: branch == 'master'
+    run:
+      when: branch != 'master'
     task:
       prologue:
         commands:
@@ -34,6 +34,7 @@ blocks:
       jobs:
         - name: "build"
           commands:
+            - cd docs
             - npm install
             - npm run build
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,7 @@ blocks:
   - name: "Build and Test"
     dependencies: []
     skip:
-      when: "branch == 'master'"
+      when: branch == 'master'
     task:
       prologue:
         commands:
@@ -40,7 +40,7 @@ blocks:
   - name: "Deploy GitHub Pages"
     dependencies: []
     skip:
-      when: "branch != 'master'"
+      when: branch != 'master'
     task:
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,4 +34,4 @@ blocks:
           commands:
             - cd docs
             - npm install
-            - npm run deploy
+            - USE_SSH=true npm run deploy

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,8 +22,9 @@ queue:
     processing: parallel
 
 blocks:
-  - name: "Deploy GitHub Pages"
+  - name: "Build and Test"
     dependencies: []
+    when: "branch != 'master'"
     task:
       prologue:
         commands:
@@ -32,6 +33,20 @@ blocks:
       jobs:
         - name: "build"
           commands:
+            - npm install
+            - npm run build
+
+  - name: "Deploy GitHub Pages"
+    dependencies: []
+    when: "branch == 'master'"
+    task:
+      prologue:
+        commands:
+          - sem-version node 22
+          - checkout
+      jobs:
+        - name: "build and deploy"
+          commands:
             - cd docs
             - npm install
-            - USE_SSH=true npm run deploy
+            - GIT_USER=semaphore npm run deploy

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-2
 
 auto_cancel:
   running:
@@ -21,39 +21,17 @@ queue:
   - when: "branch != 'master'"
     processing: parallel
 
-global_job_config:
-  prologue:
-    commands:
-      - checkout
-      - make show-args
-      - . vault-setup
-      - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
-      - make init-ci
-  epilogue:
-    always:
-      commands:
-        - make epilogue-ci
-
 blocks:
-  - name: "Build, Test, Release"
-    run:
-      # don't run the build or unit tests on non-functional changes...
-      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'master'})"
+  - name: "Deploy GitHub Pages"
+    dependencies: []
     task:
-      # You can customize your CI job here
-      #      env_vars:
-      #        # custom env_vars
-      #      prologue:
-      #        commands:
-      #          # custom vault secrets
-      #          # custom prologue commands
+      prologue:
+        commands:
+          - sem-version node 22
+          - checkout
       jobs:
-        - name: "Build, Test, Release"
+        - name: "build"
           commands:
-            - make build
-            - make test
-            - make release-ci
-      epilogue:
-        always:
-          commands:
-            - make testbreak-after
+            - cd docs
+            - npm install
+            - npm run deploy

--- a/docs/src/pages/automation.mdx
+++ b/docs/src/pages/automation.mdx
@@ -39,7 +39,7 @@ Working through each KSI control, Confluent has defined a series of individual c
 the respective KSI. Combined, these checks form an aggregate compliance score for the KSI.
 
 :::tip
-For more information on how Confluent has implemented these controls, please refer to the [Models](./docs/models/intro) section of the documentation.
+For more information on how Confluent has implemented these controls, please refer to the [Models](./docs/category/ksi-ced) section of the documentation.
 :::
 
 ## Automation with Airflow


### PR DESCRIPTION
When not on `master`, simply test a build of the docs to verify functionality. 

On `master`, we configure it to deploy the new site manifests