### PR TITLE
Update filters on publicly accessible resources

### DIFF
--- a/macros/aws/ec2/instances_reachable_with_public_ip.sql
+++ b/macros/aws/ec2/instances_reachable_with_public_ip.sql
@@ -7,14 +7,22 @@
 {% macro bigquery__instances_reachable_with_public_ip() %}
 SELECT
     'EC2 Instances with a public IP address' as title,
-    account_id,
-    arn AS resource_id,
+    aws_ec2_instances.account_id,
+    aws_ec2_instances.arn AS resource_id,
     'aws_ec2_instances' as resource_type,
     'instance_with_public_ip' as reachability_type,
+    ingress_rules.from_port as from_port,
+    ingress_rules.to_port as to_port,
+    CAST(ingress_rules.ip_protocol AS STRING) as protocol,
     public_ip_address as endpoint,
     'ip_address' as endpoint_type
 FROM
-    {{ full_table_name("aws_ec2_instances") }}
+    {{ full_table_name("aws_ec2_instances") }},
+    UNNEST(JSON_QUERY_ARRAY(security_groups, "$")) as security_group
+LEFT JOIN {{ ref("aws_compliance__security_group_ingress_rules") }} as ingress_rules
+    ON JSON_VALUE(security_group, "$.GroupId") = ingress_rules.id
 WHERE {{ partition_filter() }}
 AND public_ip_address IS NOT NULL
+AND ingress_rules.id IS NOT NULL
+AND ingress_rules.ip = "0.0.0.0/0"
     {% endmacro %}

--- a/macros/aws/elbv2/public_facing_elbv2.sql
+++ b/macros/aws/elbv2/public_facing_elbv2.sql
@@ -7,14 +7,22 @@
 {% macro bigquery__public_facing_elbv2() %}
 SELECT
     'ALBs that are internet facing' as title,
-    account_id,
-    arn AS resource_id,
+    aws_elbv2_load_balancers.account_id,
+    aws_elbv2_load_balancers.arn AS resource_id,
     'aws_elbv2_load_balancers' as resource_type,
     'alb_public_facing' as reachability_type,
+    ingress_rules.from_port as from_port,
+    ingress_rules.to_port as to_port,
+    CAST(ingress_rules.ip_protocol AS STRING) as protocol,
     dns_name as endpoint,
     'dns_name' as endpoint_type
 FROM
-    {{ full_table_name("aws_elbv2_load_balancers") }}
+    {{ full_table_name("aws_elbv2_load_balancers") }},
+    UNNEST(security_groups) AS security_group
+LEFT JOIN {{ ref("aws_compliance__security_group_ingress_rules") }} as ingress_rules
+    ON security_group = ingress_rules.id
 WHERE {{ partition_filter() }}
   AND scheme = 'internet-facing'
+  AND ingress_rules.id IS NOT NULL
+  AND ingress_rules.ip = "0.0.0.0/0"
     {% endmacro %}

--- a/macros/aws/lambda/lambda_functions_with_public_access.sql
+++ b/macros/aws/lambda/lambda_functions_with_public_access.sql
@@ -7,11 +7,14 @@
 {% macro bigquery__lambda_functions_with_public_access() %}
 select
     'Lambda functions with public access' as title,
-    account_id,
-    arn as resource_id,
+    aws_lambda_functions.account_id,
+    aws_lambda_functions.arn as resource_id,
     'aws_lambda_functions' as resource_type,
     'public_invocation' as reachability_type,
-    NULL as endpoint,
+    NULL as from_port,
+    NULL as to_port,
+    NULL as protocol,
+    '' as endpoint,
     NULL as endpoint_type
 from {{ full_table_name("aws_lambda_functions") }},
      UNNEST(JSON_QUERY_ARRAY(policy_document.Statement)) AS statement

--- a/macros/aws/rds/rds_instances_reachable_with_public_ip.sql
+++ b/macros/aws/rds/rds_instances_reachable_with_public_ip.sql
@@ -11,6 +11,9 @@ SELECT
     arn AS resource_id,
     'aws_rds_instances' as resource_type,
     'publicly_accessible' as reachability_type,
+    NULL as from_port,
+    NULL as to_port,
+    '' as protocol,
     JSON_EXTRACT_SCALAR(endpoint, "$.Address") as endpoint,
     'dns_name' as endpoint_type
 FROM

--- a/macros/k8s/kubernetes_resources_backing_albs.sql
+++ b/macros/k8s/kubernetes_resources_backing_albs.sql
@@ -39,12 +39,20 @@ SELECT
     CONCAT(k8s.context, '.', k8s.namespace, '.', k8s_resource_type, '.', k8s.name) as resource_id,
     k8s_resource_type as resource_type,
     'publicly_accessible' as reachability_type,
+    ingress_rules.from_port as from_port,
+    ingress_rules.to_port as to_port,
+    CAST(ingress_rules.ip_protocol AS STRING) as protocol,
     alb.dns_name as endpoint,
     'dns_name' as endpoint_type
 FROM
     k8s_resources as k8s
 LEFT JOIN {{ full_table_name("aws_elbv2_load_balancers") }} as alb
-ON k8s.hostname = alb.dns_name
+    ON k8s.hostname = alb.dns_name
+LEFT JOIN UNNEST(alb.security_groups) AS security_group
+LEFT JOIN {{ ref("aws_compliance__security_group_ingress_rules") }} as ingress_rules
+    ON JSON_VALUE(security_group, "$.GroupId") = ingress_rules.id
 WHERE {{ partition_filter() }}
-AND alb.scheme = 'internet-facing'
+    AND alb.scheme = 'internet-facing'
+    AND ingress_rules.id IS NOT NULL
+    AND ingress_rules.ip = "0.0.0.0/0"
     {% endmacro %}

--- a/macros/k8s/kubernetes_resources_reachable_from_api_gateway.sql
+++ b/macros/k8s/kubernetes_resources_reachable_from_api_gateway.sql
@@ -25,7 +25,7 @@ cleaned_hosts as (
         ELSE addr
       END AS cleaned_host
     from gateway_args
-),
+)
 select
     'Kubernetes services reachable from API Gateway' as title,
     cleaned_hosts.context as account_id,

--- a/macros/k8s/kubernetes_resources_reachable_from_api_gateway.sql
+++ b/macros/k8s/kubernetes_resources_reachable_from_api_gateway.sql
@@ -25,13 +25,16 @@ cleaned_hosts as (
         ELSE addr
       END AS cleaned_host
     from gateway_args
-)
+),
 select
     'Kubernetes services reachable from API Gateway' as title,
     cleaned_hosts.context as account_id,
     CONCAT(cleaned_hosts.context, '.', COALESCE(SPLIT(cleaned_host, '.')[SAFE_OFFSET(1)], '{{ var("api_gateway_namespace") }}'), '.service.', SPLIT(cleaned_host, '.')[SAFE_OFFSET(0)]) as resource_id,
     'service' as resource_type,
     'api_gateway_proxy' as reachability_type,
+    NULL as from_port,
+    NULL as to_port,
+    '' as protocol,
     '' as endpoint,
     'api_gateway' as endpoint_type
 from cleaned_hosts


### PR DESCRIPTION
- Add `to_port`, `from_port`, and `protocol` to all models that support those datapoints 
- Filter the following resources to only return objects with a security group allowing `0.0.0.0/0` 
   - EC2 instances with a public IP 
   - ALBs with `scheme: internet-facing` 
   - K8S resources that back internet-facing ALBs