### PR TITLE
[APPSEC-6902] Replace npm install with npm ci in Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,7 +48,7 @@ blocks:
         - name: "build"
           commands:
             - cd docs
-            - npm install
+            - npm ci
             - npm run build
 
   - name: "Deploy GitHub Pages"
@@ -64,5 +64,5 @@ blocks:
         - name: "build and deploy"
           commands:
             - cd docs
-            - npm install
+            - npm ci
             - USE_SSH=true npm run deploy


### PR DESCRIPTION
## Summary
- Replaces bare `npm install` with `npm ci` in Semaphore CI configs
- `npm ci` installs strictly from `package-lock.json` and fails on any mismatch, ensuring reproducible CI builds
- This change will act as a mitigation against malicious dependencies being pulled into CI

## Test plan
- [ ] Verify Semaphore CI pipeline passes with `npm ci`
- [ ] Confirm `package-lock.json` is committed and up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)